### PR TITLE
Chore: reduce attack surface and size for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN set -ex; \
     tmpdir="$(mktemp -d)"; \
     cd "$tmpdir"; \
     apt-get update; \
-    apt-get install -y $BASE_PKGS; \
+    apt-get install -y --no-install-recommends $BASE_PKGS; \
     git clone https://github.com/varnish/pkg-hitch.git; \
     cd pkg-hitch; \
     git checkout ${PKGCOMMIT}; \
@@ -29,7 +29,7 @@ RUN set -ex; \
     sed -i '' debian/hitch*; \
     dpkg-buildpackage -us -uc -j"$(nproc)"; \
     apt-get -y purge --auto-remove hitch-build-deps $BASE_PKGS; \
-    apt-get -y install ../*.deb; \
+    apt-get -y --no-install-recommends install ../*.deb; \
     sed -i 's/daemon = on/daemon = off/' /etc/hitch/hitch.conf; \
     rm -rf /var/lib/apt/lists/* "$tmpdir"
 


### PR DESCRIPTION
Hi,

This pull request includes a small improvement for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

In detail:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.